### PR TITLE
Implement YAML strategy system

### DIFF
--- a/core/graph.py
+++ b/core/graph.py
@@ -4,10 +4,22 @@ from langgraph.graph import StateGraph, END
 from langgraph.checkpoint.memory import MemorySaver
 
 from .state import State
+from strategies import load_strategy, select_strategy
 
 
 def scope(state: State) -> State:
-    """Placeholder scope phase."""
+    """Scope phase selects a strategy based on state fields."""
+    if (
+        state.strategy_slug is None
+        and state.category
+        and state.time_window
+        and state.depth
+    ):
+        slug = select_strategy(state.category, state.time_window, state.depth)
+        if slug:
+            state.strategy_slug = slug
+            # Load strategy to surface validation errors early.
+            load_strategy(slug)
     return state
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ requires-python = ">=3.12"
 dependencies = [
   "langgraph>=0.6",
   "pydantic>=2.0",
+  "pyyaml>=6.0",
+  "jsonschema>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/roadmap.md
+++ b/roadmap.md
@@ -167,13 +167,16 @@ Each renderer enforces per‑section citation minima before emitting.
 8. **Strategy selector** (pure function): `(category, time_window, depth) -> strategy_slug`.
 9. **Strategy library MVP**:
 
-   * `news/real_time_briefing.yaml` (Sonar→Exa flow; strict time window)
-   * `general/week_overview.yaml` (broader Exa window, optional Sonar)
-   * `company/dossier.yaml` (Exa keyword + official sites bias)
+ * `news/real_time_briefing.yaml` (Sonar→Exa flow; strict time window)
+  * `general/week_overview.yaml` (broader Exa window, optional Sonar)
+  * `company/dossier.yaml` (Exa keyword + official sites bias)
 10. **Macros/partials**: Extract common blocks:
 
     * `sonar_first_look`, `exa_primary_news_search`, `exa_contents_focus`, `exa_find_similar`, `exa_answer_conflict`
     * Reuse via `include:` within YAML.
+
+**Status:** Phase 2 complete — YAML schema/loader, selector, initial strategy library, and macros implemented.
+**Next:** Phase 3 — Tool adapter registry.
 
 > By driving **search type**, **category**, and date filters from YAML you exploit Exa’s strengths (news category, `keyword/neural/auto`) deterministically. ([Exa][8])
 

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+import json
+from jsonschema import validate
+from pydantic import BaseModel, Field
+
+
+# Pydantic models -----------------------------------------------------------
+
+class ToolStep(BaseModel):
+    """Single step in a tool chain."""
+
+    name: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+    loop: Optional[int] = None
+
+
+class StrategyMeta(BaseModel):
+    slug: str
+    version: int
+    category: str
+    time_window: str
+    depth: str
+
+
+class Strategy(BaseModel):
+    meta: StrategyMeta
+    tool_chain: List[ToolStep]
+    queries: Dict[str, str] = Field(default_factory=dict)
+    filters: Dict[str, Any] = Field(default_factory=dict)
+    quorum: Dict[str, Any] = Field(default_factory=dict)
+    render: Dict[str, Any] = Field(default_factory=dict)
+    limits: Dict[str, Any] = Field(default_factory=dict)
+
+
+# Loader --------------------------------------------------------------------
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_SCHEMA = json.loads((_PACKAGE_DIR / "schema.json").read_text())
+
+
+def _resolve_includes(data: Any) -> Any:
+    """Recursively resolve `include:` directives using macros."""
+    if isinstance(data, dict):
+        if set(data.keys()) == {"include"}:
+            macro_path = _PACKAGE_DIR / "macros" / f"{data['include']}.yaml"
+            included = yaml.safe_load(macro_path.read_text())
+            return _resolve_includes(included)
+        return {k: _resolve_includes(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_resolve_includes(item) for item in data]
+    return data
+
+
+def load_strategy(slug: str) -> Strategy:
+    """Load and validate a strategy by slug."""
+    path = _PACKAGE_DIR / f"{slug}.yaml"
+    raw = yaml.safe_load(path.read_text())
+    raw = _resolve_includes(raw)
+    validate(instance=raw, schema=_SCHEMA)
+    return Strategy.model_validate(raw)
+
+
+# Selector ------------------------------------------------------------------
+
+_STRATEGY_TABLE: Dict[Tuple[str, str, str], str] = {
+    ("news", "day", "brief"): "news/real_time_briefing",
+    ("general", "week", "overview"): "general/week_overview",
+    ("company", "month", "deep"): "company/dossier",
+}
+
+
+def select_strategy(category: str, time_window: str, depth: str) -> Optional[str]:
+    """Deterministic rules to select a strategy slug."""
+    return _STRATEGY_TABLE.get((category, time_window, depth))
+
+
+__all__ = ["Strategy", "load_strategy", "select_strategy"]

--- a/strategies/company/dossier.yaml
+++ b/strategies/company/dossier.yaml
@@ -1,0 +1,27 @@
+meta:
+  slug: company/dossier
+  version: 1
+  category: company
+  time_window: month
+  depth: deep
+tool_chain:
+  - include: exa_primary_news_search
+  - include: exa_contents_focus
+queries:
+  exa_search: "{{topic}} company profile"
+filters:
+  recency: month
+  domains:
+    allow:
+      - official
+quorum:
+  min_sources: 3
+  require_official: true
+render:
+  type: dossier
+  sections:
+    - overview
+    - financials
+    - news
+limits:
+  max_results: 10

--- a/strategies/general/week_overview.yaml
+++ b/strategies/general/week_overview.yaml
@@ -1,0 +1,24 @@
+meta:
+  slug: general/week_overview
+  version: 1
+  category: general
+  time_window: week
+  depth: overview
+tool_chain:
+  - include: exa_primary_news_search
+  - include: sonar_first_look
+  - include: exa_contents_focus
+queries:
+  exa_search: "{{topic}}"
+  sonar: "background {{topic}}"
+filters:
+  recency: week
+quorum:
+  min_sources: 3
+render:
+  type: memo
+  sections:
+    - summary
+    - key developments
+limits:
+  max_results: 7

--- a/strategies/macros/exa_answer_conflict.yaml
+++ b/strategies/macros/exa_answer_conflict.yaml
@@ -1,0 +1,3 @@
+name: exa_answer
+params:
+  max_tokens: 256

--- a/strategies/macros/exa_contents_focus.yaml
+++ b/strategies/macros/exa_contents_focus.yaml
@@ -1,0 +1,3 @@
+name: exa_contents_focus
+params:
+  top_k: 2

--- a/strategies/macros/exa_find_similar.yaml
+++ b/strategies/macros/exa_find_similar.yaml
@@ -1,0 +1,3 @@
+name: exa_find_similar
+params:
+  top_k: 3

--- a/strategies/macros/exa_primary_news_search.yaml
+++ b/strategies/macros/exa_primary_news_search.yaml
@@ -1,0 +1,5 @@
+name: exa_search_primary
+params:
+  type: auto
+  category: news
+  date_window: day

--- a/strategies/macros/sonar_first_look.yaml
+++ b/strategies/macros/sonar_first_look.yaml
@@ -1,0 +1,4 @@
+name: sonar_snapshot
+params:
+  model: sonar
+  recency: day

--- a/strategies/news/real_time_briefing.yaml
+++ b/strategies/news/real_time_briefing.yaml
@@ -1,0 +1,25 @@
+meta:
+  slug: news/real_time_briefing
+  version: 1
+  category: news
+  time_window: day
+  depth: brief
+tool_chain:
+  - include: sonar_first_look
+  - include: exa_primary_news_search
+  - include: exa_contents_focus
+queries:
+  sonar: "latest {{topic}}"
+  exa_search: "{{topic}} news"
+filters:
+  recency: day
+quorum:
+  min_sources: 3
+  require_official: true
+render:
+  type: briefing
+  sections:
+    - top stories
+    - analysis
+limits:
+  max_results: 5

--- a/strategies/schema.json
+++ b/strategies/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["meta", "tool_chain"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["slug", "version", "category", "time_window", "depth"],
+      "properties": {
+        "slug": {"type": "string"},
+        "version": {"type": "integer"},
+        "category": {"type": "string"},
+        "time_window": {"type": "string"},
+        "depth": {"type": "string"}
+      }
+    },
+    "tool_chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {"type": "string"},
+          "params": {"type": "object"},
+          "loop": {"type": "integer"}
+        }
+      }
+    },
+    "queries": {"type": "object"},
+    "filters": {"type": "object"},
+    "quorum": {"type": "object"},
+    "render": {"type": "object"},
+    "limits": {"type": "object"}
+  }
+}

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,9 @@
+from strategies import load_strategy, select_strategy
+
+
+def test_select_and_load_strategy():
+    slug = select_strategy("news", "day", "brief")
+    assert slug == "news/real_time_briefing"
+    strategy = load_strategy(slug)
+    assert strategy.meta.slug == slug
+    assert strategy.tool_chain[0].name == "sonar_snapshot"


### PR DESCRIPTION
## Summary
- add configurable YAML strategy schema, loader with macro includes, and deterministic selector
- integrate strategy selection into scope node
- document completion of Phase 2 roadmap and note next steps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b595fa7e44832ab1d1083f51f89fb9