### PR TITLE
Add tool adapter registry and adapters

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,69 @@
+from core.state import Evidence
+from tools import register_tool, get_tool, SonarAdapter, ExaAdapter
+
+
+class DummyAdapter:
+    name = "dummy"
+
+    def call(self, *args, **kwargs):
+        return [Evidence(url="http://example.com", tool="dummy")]
+
+
+def test_registry_register_and_get():
+    register_tool(DummyAdapter())
+    tool = get_tool("dummy")
+    result = tool.call()
+    assert result[0].tool == "dummy"
+
+
+def test_sonar_adapter_normalizes(monkeypatch):
+    adapter = SonarAdapter(api_key="test")
+
+    def fake_chat(messages, **params):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "citations": [
+                            {
+                                "url": "http://example.com",
+                                "title": "Example",
+                                "publisher": "ExamplePub",
+                                "publishedAt": "2024-01-01",
+                                "snippet": "Snippet",
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(adapter, "_chat_completion", fake_chat)
+    evidence = adapter.call("hello world")
+    assert evidence[0].url == "http://example.com"
+    assert evidence[0].tool == "sonar"
+
+
+def test_exa_adapter_search_normalizes(monkeypatch):
+    adapter = ExaAdapter(api_key="test")
+
+    class FakeClient:
+        def search(self, query, **params):
+            return {
+                "results": [
+                    {
+                        "url": "http://exa.example",
+                        "title": "Exa",
+                        "source": "ExaSource",
+                        "publishedDate": "2024-02-02",
+                        "snippet": "Snippet",
+                        "score": 0.5,
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(adapter, "_client", lambda: FakeClient())
+    evidence = adapter.search("query")
+    assert evidence[0].url == "http://exa.example"
+    assert evidence[0].publisher == "ExaSource"
+    assert evidence[0].tool == "exa"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,7 @@
+"""Tool adapter registry and built-in adapters."""
+
+from .registry import register_tool, get_tool
+from .sonar import SonarAdapter
+from .exa import ExaAdapter
+
+__all__ = ["register_tool", "get_tool", "SonarAdapter", "ExaAdapter"]

--- a/tools/exa.py
+++ b/tools/exa.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Adapter for the Exa search API."""
+
+from typing import Any, List
+import os
+
+from core.state import Evidence
+
+
+class ExaAdapter:
+    """Wrapper around ``exa-py`` client that normalizes outputs."""
+
+    name = "exa"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("EXA_API_KEY")
+        if not self.api_key:
+            raise ValueError("Exa API key required")
+
+    def _client(self):
+        from exa_py import Exa  # Imported lazily
+
+        return Exa(self.api_key)
+
+    def search(self, query: str, **params: Any) -> List[Evidence]:
+        client = self._client()
+        response = client.search(query, **params)
+        results = response.get("results") if isinstance(response, dict) else getattr(response, "results", [])
+        evidence: List[Evidence] = []
+        for r in results:
+            url = r.get("url") if isinstance(r, dict) else getattr(r, "url", None)
+            evidence.append(
+                Evidence(
+                    url=url or "",
+                    title=r.get("title") if isinstance(r, dict) else getattr(r, "title", None),
+                    publisher=r.get("source") if isinstance(r, dict) else getattr(r, "source", None),
+                    date=r.get("publishedDate") if isinstance(r, dict) else getattr(r, "publishedDate", None),
+                    snippet=r.get("snippet") if isinstance(r, dict) else getattr(r, "snippet", None),
+                    tool=self.name,
+                    score=r.get("score") if isinstance(r, dict) else getattr(r, "score", None),
+                )
+            )
+        return evidence
+
+    def contents(self, url: str, **params: Any) -> Evidence:
+        client = self._client()
+        response = client.contents(url, **params)
+        text = response.get("text") if isinstance(response, dict) else getattr(response, "text", None)
+        return Evidence(url=url, snippet=text, tool=self.name)
+
+    def find_similar(self, url: str, **params: Any) -> List[Evidence]:
+        client = self._client()
+        response = client.findSimilar(url, **params)
+        results = response.get("results") if isinstance(response, dict) else getattr(response, "results", [])
+        evidence: List[Evidence] = []
+        for r in results:
+            u = r.get("url") if isinstance(r, dict) else getattr(r, "url", None)
+            evidence.append(Evidence(url=u or "", title=r.get("title") if isinstance(r, dict) else getattr(r, "title", None), tool=self.name))
+        return evidence
+
+    def answer(self, query: str, **params: Any) -> str:
+        client = self._client()
+        response = client.answer(query, **params)
+        return response.get("answer") if isinstance(response, dict) else getattr(response, "answer", "")
+
+    def call(self, *args: Any, **kwargs: Any) -> List[Evidence]:
+        """Default call proxies to ``search`` for registry uniformity."""
+        return self.search(*args, **kwargs)
+
+
+__all__ = ["ExaAdapter"]

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Simple registry for tool adapters."""
+
+from typing import Dict
+
+from .types import ToolAdapter
+
+
+_tool_registry: Dict[str, ToolAdapter] = {}
+
+
+def register_tool(adapter: ToolAdapter) -> None:
+    """Register a tool adapter by its name.
+
+    Args:
+        adapter: Tool adapter instance implementing ``ToolAdapter`` protocol.
+    """
+    _tool_registry[adapter.name] = adapter
+
+
+def get_tool(name: str) -> ToolAdapter:
+    """Retrieve a registered tool adapter by name.
+
+    Raises:
+        KeyError: If the tool is not registered.
+    """
+    try:
+        return _tool_registry[name]
+    except KeyError as exc:
+        raise KeyError(f"Tool '{name}' is not registered") from exc

--- a/tools/sonar.py
+++ b/tools/sonar.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Adapter for the Perplexity Sonar API."""
+
+from typing import Any, Dict, List
+import os
+
+from core.state import Evidence
+
+
+class SonarAdapter:
+    """Call the Sonar (Perplexity) chat completions API and normalize citations."""
+
+    name = "sonar"
+
+    def __init__(self, model: str = "sonar", api_key: str | None = None) -> None:
+        self.model = model
+        self.api_key = api_key or os.getenv("SONAR_API_KEY") or os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("Sonar API key required")
+
+    # Separate network call for easier testing
+    def _chat_completion(self, messages: List[Dict[str, str]], **params: Any) -> Any:
+        from openai import OpenAI  # Imported lazily to keep optional dependency
+
+        client = OpenAI(api_key=self.api_key)
+        return client.chat.completions.create(model=self.model, messages=messages, **params)
+
+    def call(self, prompt: str, **params: Any) -> List[Evidence]:
+        """Execute a chat completion and return normalized citation evidence."""
+        messages = [{"role": "user", "content": prompt}]
+        response = self._chat_completion(messages, **params)
+        # Response may be OpenAIObject; convert generically
+        choice = response["choices"][0] if isinstance(response, dict) else response.choices[0]
+        message = choice["message"] if isinstance(choice, dict) else choice.message
+        citations = message.get("citations", []) if isinstance(message, dict) else getattr(message, "citations", [])
+
+        evidence: List[Evidence] = []
+        for c in citations:
+            # Citations may be dicts or objects; use dict-like access
+            url = c.get("url") if isinstance(c, dict) else getattr(c, "url", None)
+            evidence.append(
+                Evidence(
+                    url=url or "",
+                    title=c.get("title") if isinstance(c, dict) else getattr(c, "title", None),
+                    publisher=c.get("publisher") if isinstance(c, dict) else getattr(c, "publisher", None),
+                    date=c.get("publishedAt") if isinstance(c, dict) else getattr(c, "publishedAt", None),
+                    snippet=c.get("snippet") if isinstance(c, dict) else getattr(c, "snippet", None),
+                    tool=self.name,
+                )
+            )
+        return evidence
+
+
+# The adapter conforms to ``ToolAdapter`` protocol
+__all__ = ["SonarAdapter"]

--- a/tools/types.py
+++ b/tools/types.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Common types for tool adapters."""
+
+from typing import Protocol, Any, List
+
+from core.state import Evidence
+
+
+class ToolAdapter(Protocol):
+    """Protocol for a tool adapter."""
+
+    name: str
+
+    def call(self, *args: Any, **kwargs: Any) -> List[Evidence]:
+        """Execute the tool and return normalized evidence records."""
+        ...


### PR DESCRIPTION
## Summary
- add registry for tool adapters and retrieval helpers
- implement Sonar and Exa adapters that normalize outputs to Evidence records
- cover registry and adapter normalization with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b598984d30832a826a5334d4f2016e