### PR TITLE
Implement scope categorizer and task splitter

### DIFF
--- a/core/scope.py
+++ b/core/scope.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+def categorize_request(request: str) -> Dict[str, str]:
+    """Return category, time window, and depth for a request using simple rules."""
+    text = request.lower()
+    if any(word in text for word in ["company", "dossier", "profile"]):
+        return {"category": "company", "time_window": "month", "depth": "deep"}
+    if any(word in text for word in ["latest", "today", "news", "breaking"]):
+        return {"category": "news", "time_window": "day", "depth": "brief"}
+    return {"category": "general", "time_window": "week", "depth": "overview"}
+
+
+def split_tasks(request: str, max_tasks: int = 5) -> List[str]:
+    """Deterministically split a request into sub-tasks."""
+    parts = re.split(r",| and | & |;|\+|/|\|", request)
+    tasks: List[str] = []
+    for part in parts:
+        cleaned = part.strip()
+        if cleaned and cleaned not in tasks:
+            tasks.append(cleaned)
+        if len(tasks) >= max_tasks:
+            break
+    if not tasks:
+        tasks = [request.strip()]
+    return tasks
+
+__all__ = ["categorize_request", "split_tasks"]

--- a/roadmap.md
+++ b/roadmap.md
@@ -177,8 +177,8 @@ Each renderer enforces per‑section citation minima before emitting.
     * `sonar_first_look`, `exa_primary_news_search`, `exa_contents_focus`, `exa_find_similar`, `exa_answer_conflict`
     * Reuse via `include:` within YAML.
 
-**Status:** Phase 2 complete — YAML schema/loader, selector, initial strategy library, and macros implemented.
-**Next:** Phase 3 — Tool adapter registry.
+**Status:** Phase 4 complete — tool registry plus scope-phase categorizer and task splitter implemented.
+**Next:** Phase 5 — Research subgraph.
 
 > By driving **search type**, **category**, and date filters from YAML you exploit Exa’s strengths (news category, `keyword/neural/auto`) deterministically. ([Exa][8])
 
@@ -200,6 +200,8 @@ Each renderer enforces per‑section citation minima before emitting.
 
 15. **Categorizer** (small model or rules first): returns `{category, time_window, depth}` (structured JSON).
 16. **Task splitter**: deterministic sub‑topic extraction (cap N); produce `tasks[]` and per‑task query variables.
+
+*Implementation:* Keyword rules map requests to existing strategy dimensions, and a delimiter-based splitter expands `tasks[]` and mirrored `queries[]`.
 
 ### Phase 5 — Research subgraph
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,6 +4,10 @@ from core.state import State
 
 def test_graph_compiles():
     graph = build_graph()
-    state = State(user_request="test")
+    state = State(user_request="economy and politics")
     result = graph.invoke(state, config={"configurable": {"thread_id": "test"}})
-    assert result["user_request"] == "test"
+    assert result["user_request"] == "economy and politics"
+    assert result["category"] == "general"
+    assert result["time_window"] == "week"
+    assert result["strategy_slug"] == "general/week_overview"
+    assert result["tasks"] == ["economy", "politics"]

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,13 @@
+from core.scope import categorize_request, split_tasks
+
+
+def test_categorize_request_news():
+    result = categorize_request("latest AI news")
+    assert result["category"] == "news"
+    assert result["time_window"] == "day"
+    assert result["depth"] == "brief"
+
+
+def test_split_tasks():
+    tasks = split_tasks("economy and politics, technology")
+    assert tasks == ["economy", "politics", "technology"]


### PR DESCRIPTION
## Summary
- add keyword-based categorizer and delimiter-driven task splitter
- integrate scope utilities into graph and populate tasks/queries
- document phase 4 completion in roadmap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59cc6c81c832aa837419de8fbab60