### PR TITLE
Implement research phase with templated tool execution

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -177,8 +177,8 @@ Each renderer enforces per‑section citation minima before emitting.
     * `sonar_first_look`, `exa_primary_news_search`, `exa_contents_focus`, `exa_find_similar`, `exa_answer_conflict`
     * Reuse via `include:` within YAML.
 
-**Status:** Phase 4 complete — tool registry plus scope-phase categorizer and task splitter implemented.
-**Next:** Phase 5 — Research subgraph.
+**Status:** Phase 5 complete — research subgraph executes YAML-defined tool chains with query templating, evidence scoring, dedupe, and per-task budgets.
+**Next:** Phase 6 — Write phase & renderers.
 
 > By driving **search type**, **category**, and date filters from YAML you exploit Exa’s strengths (news category, `keyword/neural/auto`) deterministically. ([Exa][8])
 
@@ -209,6 +209,8 @@ Each renderer enforces per‑section citation minima before emitting.
 18. **Query templating**: fill Jinja‑like templates using `{topic, subtopic, time_window, region}` consistently (no LLM improvisation).
 19. **Scoring & dedupe**: domain authority weights, recency decay, canonical URL normalization.
 20. **Evidence budget**: cap `evidence[]` per task to keep the write phase small.
+
+*Implementation:* `core.graph.research` now iterates through each task's tool chain, renders query templates, normalizes URLs with scoring and deduplication, and trims results using `limits.max_results`.
 
 ### Phase 6 — Write phase & renderers
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,33 @@
 from core.graph import build_graph
-from core.state import State
+from core.state import State, Evidence
+from tools import register_tool
+from tools import registry as reg
 
 
-def test_graph_compiles():
+class DummySonar:
+    name = "sonar"
+
+    def call(self, prompt, **params):
+        return [Evidence(url="http://sonar.example", tool="sonar")]
+
+
+class DummyExa:
+    name = "exa"
+
+    def call(self, query, **params):
+        return [Evidence(url="http://exa.example", tool="exa")]
+
+    def contents(self, url, **params):
+        return Evidence(url=url, snippet="content", tool="exa")
+
+    def find_similar(self, url, **params):
+        return []
+
+
+def test_graph_compiles(monkeypatch):
+    monkeypatch.setattr(reg, "_tool_registry", {})
+    register_tool(DummySonar())
+    register_tool(DummyExa())
     graph = build_graph()
     state = State(user_request="economy and politics")
     result = graph.invoke(state, config={"configurable": {"thread_id": "test"}})

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,64 @@
+from core.graph import research
+from core.state import State, Evidence
+from strategies import Strategy, StrategyMeta, ToolStep
+from tools import register_tool
+import strategies
+
+
+class DummySonar:
+    name = "sonar"
+
+    def call(self, prompt: str, **params):
+        return [
+            Evidence(url="http://a.com", score=0.9, tool="sonar"),
+            Evidence(url="http://b.com", score=0.8, tool="sonar"),
+        ]
+
+
+class DummyExa:
+    name = "exa"
+
+    def call(self, query: str, **params):
+        return [
+            Evidence(url="http://a.com", score=0.95, tool="exa"),
+            Evidence(url="http://c.com", score=0.7, tool="exa"),
+        ]
+
+
+def make_strategy(max_results=10):
+    meta = StrategyMeta(slug="test", version=1, category="news", time_window="day", depth="brief")
+    tool_chain = [ToolStep(name="sonar_snapshot"), ToolStep(name="exa_search_primary")]
+    queries = {"sonar": "latest {{topic}}", "exa_search": "{{topic}} news"}
+    limits = {"max_results": max_results}
+    return Strategy(meta=meta, tool_chain=tool_chain, queries=queries, limits=limits)
+
+
+def setup(monkeypatch, strategy):
+    # Reset registry and register dummy tools
+    from tools import registry as reg
+    import core.graph as graph_module
+
+    monkeypatch.setattr(reg, "_tool_registry", {})
+    register_tool(DummySonar())
+    register_tool(DummyExa())
+    monkeypatch.setattr(strategies, "load_strategy", lambda slug: strategy)
+    monkeypatch.setattr(graph_module, "load_strategy", lambda slug: strategy)
+
+
+def test_research_dedupes(monkeypatch):
+    strategy = make_strategy(max_results=10)
+    setup(monkeypatch, strategy)
+    state = State(user_request="test", tasks=["alpha"], strategy_slug="test")
+    new_state = research(state)
+    assert len(new_state.evidence) == 3  # one duplicate removed from four inputs
+    urls = sorted(ev.url for ev in new_state.evidence)
+    assert urls == ["http://a.com", "http://b.com", "http://c.com"]
+
+
+def test_research_respects_budget(monkeypatch):
+    strategy = make_strategy(max_results=1)
+    setup(monkeypatch, strategy)
+    state = State(user_request="test", tasks=["alpha"], strategy_slug="test")
+    new_state = research(state)
+    assert len(new_state.evidence) == 1
+    assert new_state.evidence[0].url == "http://a.com"


### PR DESCRIPTION
## Summary
- Add research-phase workflow executing YAML-defined tool chains with templated queries
- Normalize URLs, score evidence and enforce per-task result caps
- Mark Phase 5 complete in roadmap and document research implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a13e6858832a83a6503217c1d7cb