### PR TITLE
Add QC-lite phase and tests

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -177,8 +177,8 @@ Each renderer enforces per‑section citation minima before emitting.
     * `sonar_first_look`, `exa_primary_news_search`, `exa_contents_focus`, `exa_find_similar`, `exa_answer_conflict`
     * Reuse via `include:` within YAML.
 
-**Status:** Phase 5 complete — research subgraph executes YAML-defined tool chains with query templating, evidence scoring, dedupe, and per-task budgets.
-**Next:** Phase 7 — QC‑lite.
+**Status:** Phase 7 complete — QC‑lite checks ensure structure, citations, and source quorum.
+**Next:** Phase 8 — Delivery & sinks.
 
 > By driving **search type**, **category**, and date filters from YAML you exploit Exa’s strengths (news category, `keyword/neural/auto`) deterministically. ([Exa][8])
 
@@ -218,7 +218,7 @@ Each renderer enforces per‑section citation minima before emitting.
 22. Templates render deterministic section headings with bullet summaries.
 23. Citations assembled from `evidence[]` with publisher, date, and URL, avoiding Sonar as a cited source.
 
-### Phase 7 — QC‑lite
+### Phase 7 — QC‑lite *(completed)*
 
 24. **Structure check**: sections required by renderer present.
 25. **Citation check**: ≥1 URL per section; dedupe; dates present when available; all URLs in time window.

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from core.graph import qc
+from core.state import State, Evidence
+from strategies import Strategy, StrategyMeta
+import strategies
+import core.graph as graph_module
+
+
+def _make_strategy():
+    return Strategy(
+        meta=StrategyMeta(
+            slug="test",
+            version=1,
+            category="news",
+            time_window="day",
+            depth="brief",
+        ),
+        tool_chain=[],
+        render={"type": "briefing", "sections": ["summary"]},
+        quorum={"min_sources": 1},
+        filters={"recency": "week"},
+    )
+
+
+def test_qc_passes_with_valid_data(monkeypatch):
+    strategy = _make_strategy()
+    monkeypatch.setattr(strategies, "load_strategy", lambda slug: strategy)
+    monkeypatch.setattr(graph_module, "load_strategy", lambda slug: strategy)
+
+    today = datetime.utcnow().date().isoformat()
+    state = State(
+        user_request="test",
+        strategy_slug="test",
+        sections=["## summary"],
+        citations=["A ({} ) http://a.com".format(today)],
+        evidence=[Evidence(url="http://a.com", date=today)],
+    )
+    new_state = qc(state)
+    assert new_state.errors == []
+
+
+def test_qc_records_errors(monkeypatch):
+    strategy = _make_strategy()
+    strategy.quorum = {"min_sources": 2}
+    monkeypatch.setattr(strategies, "load_strategy", lambda slug: strategy)
+    monkeypatch.setattr(graph_module, "load_strategy", lambda slug: strategy)
+
+    old_date = (datetime.utcnow().date().replace(day=1)).isoformat()
+    state = State(
+        user_request="test",
+        strategy_slug="test",
+        sections=[],
+        citations=[],
+        evidence=[Evidence(url="http://a.com", date=old_date)],
+    )
+    new_state = qc(state)
+    assert any("missing section" in e for e in new_state.errors)
+    assert any("insufficient sources" in e for e in new_state.errors)


### PR DESCRIPTION
## Summary
- implement QC-lite step with structure, citation, recency and quorum checks and integrate into graph
- mark roadmap phase 7 complete
- add unit tests for QC-lite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ab2137f0832a9e260c418bebc336