### PR TITLE
feat: add optional LLM-based scoping

### DIFF
--- a/core/scope.py
+++ b/core/scope.py
@@ -1,11 +1,62 @@
 from __future__ import annotations
 
+import json
+import os
 import re
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
+
+
+_LLM_CACHE: Dict[str, Dict[str, Any]] = {}
+
+
+def _llm_scope(request: str) -> Optional[Dict[str, Any]]:
+    """Try to use an LLM to scope a request. Returns None on failure."""
+    if request in _LLM_CACHE:
+        return _LLM_CACHE[request]
+    try:  # Import inside the function so the dependency is optional.
+        from openai import OpenAI  # type: ignore
+    except Exception:
+        return None
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        client = OpenAI(api_key=api_key)
+        prompt = (
+            "Classify the following user request into 'category' (news, company, "
+            "general), determine 'time_window' (day, week, month) and 'depth' "
+            "(brief, overview, deep). Also provide a list of short 'tasks' that "
+            "cover the request. Respond using JSON with keys: category, "
+            "time_window, depth, tasks.\nRequest: " + request
+        )
+        response = client.responses.create(
+            model="gpt-4o-mini",
+            input=prompt,
+            response_format={"type": "json_object"},
+        )
+        raw = response.output[0].content[0].text  # type: ignore
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            _LLM_CACHE[request] = data
+            return data
+    except Exception:
+        return None
+    return None
 
 
 def categorize_request(request: str) -> Dict[str, str]:
-    """Return category, time window, and depth for a request using simple rules."""
+    """Return category, time window, and depth for a request."""
+    llm = _llm_scope(request)
+    if llm:
+        return {
+            "category": llm.get("category", "general"),
+            "time_window": llm.get("time_window", "week"),
+            "depth": llm.get("depth", "overview"),
+        }
+
+    # Heuristic fallback
     text = request.lower()
     if any(word in text for word in ["company", "dossier", "profile"]):
         return {"category": "company", "time_window": "month", "depth": "deep"}
@@ -15,7 +66,14 @@ def categorize_request(request: str) -> Dict[str, str]:
 
 
 def split_tasks(request: str, max_tasks: int = 5) -> List[str]:
-    """Deterministically split a request into sub-tasks."""
+    """Split a request into sub-tasks."""
+    llm = _llm_scope(request)
+    if llm:
+        tasks = llm.get("tasks", [])
+        if isinstance(tasks, list) and tasks:
+            return [t for t in tasks if t][:max_tasks]
+
+    # Heuristic fallback
     parts = re.split(r",| and | & |;|\+|/|\|", request)
     tasks: List[str] = []
     for part in parts:
@@ -28,4 +86,20 @@ def split_tasks(request: str, max_tasks: int = 5) -> List[str]:
         tasks = [request.strip()]
     return tasks
 
-__all__ = ["categorize_request", "split_tasks"]
+
+def scope_request(request: str, max_tasks: int = 5) -> Dict[str, Any]:
+    """Return category/time window/depth and tasks for a request."""
+    llm = _llm_scope(request)
+    if llm:
+        return {
+            "category": llm.get("category", "general"),
+            "time_window": llm.get("time_window", "week"),
+            "depth": llm.get("depth", "overview"),
+            "tasks": [t for t in llm.get("tasks", []) if t][:max_tasks],
+        }
+    cat = categorize_request(request)
+    tasks = split_tasks(request, max_tasks)
+    return {**cat, "tasks": tasks}
+
+
+__all__ = ["categorize_request", "split_tasks", "scope_request"]

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,4 +1,4 @@
-from core.scope import categorize_request, split_tasks
+from core.scope import categorize_request, split_tasks, scope_request
 
 
 def test_categorize_request_news():
@@ -11,3 +11,10 @@ def test_categorize_request_news():
 def test_split_tasks():
     tasks = split_tasks("economy and politics, technology")
     assert tasks == ["economy", "politics", "technology"]
+
+
+def test_scope_request_fallback():
+    result = scope_request("economy and politics")
+    assert result["category"] == "general"
+    assert result["time_window"] == "week"
+    assert result["tasks"] == ["economy", "politics"]


### PR DESCRIPTION
## Summary
- integrate optional OpenAI `gpt-4o-mini` call for request classification and task generation
- maintain deterministic heuristics as fallback
- add scope_request convenience helper and test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1402798832a8338ff87db6d03a1