### PR TITLE
feat: add LLM-based renderer

### DIFF
--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Protocol
 import json
+import os
 
 from core.state import Evidence
 
@@ -90,6 +91,77 @@ class JSONRenderer(_BaseRenderer):
         return {"sections": rendered, "citations": citations}
 
 
+class LLMRenderer:
+    """Renderer that asks an LLM to craft polished paragraphs."""
+
+    name = "llm"
+
+    def __init__(self, model: str = "gpt-4o-mini", api_key: str | None = None) -> None:
+        self.model = model
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+
+    # Separated for easier monkeypatching in tests
+    def _chat_completion(self, messages: List[Dict[str, str]]) -> str:
+        if not self.api_key:
+            raise ValueError("OpenAI API key required")
+        from openai import OpenAI  # Imported lazily to keep optional dependency
+
+        client = OpenAI(api_key=self.api_key)
+        response = client.chat.completions.create(model=self.model, messages=messages)
+        choice = response["choices"][0] if isinstance(response, dict) else response.choices[0]
+        message = choice["message"] if isinstance(choice, dict) else choice.message
+        return (
+            message.get("content")
+            if isinstance(message, dict)
+            else getattr(message, "content", "")
+        )
+
+    def _cluster_evidence(
+        self, sections: List[str], evidence: List[Evidence]
+    ) -> Dict[str, List[Evidence]]:
+        groups: Dict[str, List[Evidence]] = {name: [] for name in sections}
+        for ev in evidence:
+            text = f"{ev.title or ''} {ev.snippet or ''}".lower()
+            best = sections[0] if sections else ""
+            best_score = -1
+            for name in sections:
+                score = 0
+                for word in name.lower().split():
+                    if word in text:
+                        score += 1
+                if score > best_score:
+                    best_score = score
+                    best = name
+            groups.setdefault(best, []).append(ev)
+        return groups
+
+    def render(self, sections: List[str], evidence: List[Evidence]) -> Dict[str, List[str]]:
+        grouped = self._cluster_evidence(sections, evidence)
+        rendered: List[str] = []
+        for name in sections:
+            evs = grouped.get(name, [])
+            bullet = "\n".join(
+                f"- {ev.title or ev.snippet or ev.url}" for ev in evs
+            )
+            prompt = (
+                f"You are a skilled researcher. Write a polished paragraph for the section"
+                f" '{name}' using the evidence below.\n{bullet}"
+            )
+            text = self._chat_completion([{"role": "user", "content": prompt}]) if evs else ""
+            rendered.append(f"## {name}\n\n{text.strip()}" if text else f"## {name}")
+
+        citations: List[str] = []
+        seen: set[str] = set()
+        for ev in evidence:
+            url = ev.url
+            if url and url not in seen:
+                seen.add(url)
+                publisher = ev.publisher or "Unknown"
+                date = ev.date or "n.d."
+                citations.append(f"{publisher} ({date}) {url}")
+        return {"sections": rendered, "citations": citations}
+
+
 _RENDERERS = {
     r.name: r
     for r in [
@@ -99,6 +171,7 @@ _RENDERERS = {
         FactCheckRenderer(),
         QARenderer(),
         JSONRenderer(),
+        LLMRenderer(),
     ]
 }
 
@@ -120,4 +193,5 @@ __all__ = [
     "FactCheckRenderer",
     "QARenderer",
     "JSONRenderer",
+    "LLMRenderer",
 ]

--- a/tests/test_llm_renderer.py
+++ b/tests/test_llm_renderer.py
@@ -1,0 +1,39 @@
+from core.graph import write
+from core.state import State, Evidence
+from strategies import Strategy, StrategyMeta
+import strategies
+import renderers
+
+
+def test_llm_renderer_generates_sections(monkeypatch):
+    strategy = Strategy(
+        meta=StrategyMeta(
+            slug="test",
+            version=1,
+            category="news",
+            time_window="day",
+            depth="brief",
+        ),
+        tool_chain=[],
+        render={"type": "llm", "sections": ["alpha", "beta"]},
+    )
+    monkeypatch.setattr(strategies, "load_strategy", lambda slug: strategy)
+    import core.graph as graph_module
+    monkeypatch.setattr(graph_module, "load_strategy", lambda slug: strategy)
+
+    llm_renderer = renderers.get_renderer("llm")
+    monkeypatch.setattr(llm_renderer, "_chat_completion", lambda messages: "Rendered paragraph")
+
+    state = State(
+        user_request="test",
+        strategy_slug="test",
+        evidence=[
+            Evidence(url="http://a.com", title="alpha news", snippet="details alpha"),
+            Evidence(url="http://b.com", title="beta update", snippet="details beta"),
+        ],
+    )
+    new_state = write(state)
+    assert len(new_state.sections) == 2
+    assert new_state.sections[0].startswith("## alpha")
+    assert "Rendered paragraph" in new_state.sections[0]
+    assert len(new_state.citations) == 2


### PR DESCRIPTION
## Summary
- add `LLMRenderer` that clusters evidence by section and prompts an LLM to craft polished paragraphs
- register the new renderer so strategies can select `type: llm`
- cover the renderer with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1423500832aaa60d469f917ad62